### PR TITLE
docs: convert to archive style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://heatbadger.now.sh/github/readme/contributte/componette-design/)
+![](https://heatbadger.now.sh/github/readme/contributte/componette-design/?deprecated=1)
 
 <p align=center>
   <a href="https://bit.ly/ctteg"><img src="https://badgen.net/badge/support/gitter/cyan"></a>
@@ -33,7 +33,7 @@ Deploy site `vercel`.
 
 See [how to contribute](https://contributte.org/contributing.html) to this package.
 
-This package is currently maintaining by these authors.
+This package was maintained by these authors.
 
 <a href="https://github.com/f3l1x">
   <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">


### PR DESCRIPTION
## Summary

This PR updates the README to properly follow the archive style template:

- Added `?deprecated=1` parameter to heatbadger badge URL
- Changed Development section text from "is currently maintaining" to "was maintained" (past tense)

The repository was already mostly in archive style but these two elements needed to be corrected per the template requirements.

## Changes

- Heatbadger badge now displays deprecation indicator
- Development section uses past tense to reflect archived status

This repository points users to the replacement: [contributte/componette-site](https://github.com/contributte/componette-site)